### PR TITLE
fixed a few gcc warnings

### DIFF
--- a/src/asm8008.c
+++ b/src/asm8008.c
@@ -277,11 +277,6 @@ struct OpcdRec I8008_opcdTab[] =
 int I8008_DoCPUOpcode(int typ, int parm)
 {
     int     val;
-    int     reg1;
-    int     reg2;
-    Str255  word;
-    char    *oldLine;
-//  int     token;
 
     switch(typ)
     {

--- a/src/asmx.c
+++ b/src/asmx.c
@@ -4440,9 +4440,13 @@ void DoLabelOp(int typ, int parm, char *labl)
                     {
                         token = GetWord(labl);
                         if (token)
+                        {
                             showAddr = TRUE;
-                            while (*linePtr == ' ' || *linePtr == '\t')
-                                linePtr++;
+                        }                            
+                        while (*linePtr == ' ' || *linePtr == '\t')
+                        {
+                            linePtr++;
+                        }
 
                         if (labl[0])
                         {


### PR DESCRIPTION
Fixed a couple of gcc warnings - I'm really irked by all of the if-then-else constructs without brackets