### PR TITLE
Fix computation of S28 checksums

### DIFF
--- a/src/asmx.c
+++ b/src/asmx.c
@@ -2778,8 +2778,8 @@ void write_srec(unsigned long addr, unsigned char *buf, unsigned long len, int r
             break;
 
         case 28:
-            fprintf(object,"S%d%.2lX%.6lX", i, len+4, addr & 0xFFFFFF) + 1;
-            chksum = chksum + ((addr >> 16) & 0xFF);
+            fprintf(object,"S%d%.2lX%.6lX", i, len+4, addr & 0xFFFFFF);
+            chksum = chksum + ((addr >> 16) & 0xFF) + 1;
             break;
 
         default:


### PR DESCRIPTION
When producing output with the `-s28` option, you can't actually run the results through objcopy to get a binary out because the checksums are wrong. This PR corrects the checksum computation on S2 lines.

S19 and S37 do not share the bug.