### PR TITLE
Platform- and toolchain-specific bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Compiler flags
 #
 CC = gcc
-CFLAGS = -Wall
+CFLAGS = -Wall --std=gnu99
 LDFLAGS = 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SRCS = $(wildcard $(SRCDIR)/*$(EXT))
 # Debug build settings
 #
 DBGDIR = debug
-DBGEXE = $(addprefix $(DBGDIR)\, $(APPNAME))
+DBGEXE = $(addprefix $(DBGDIR)/, $(APPNAME))
 DBGOBJS = $(SRCS:$(SRCDIR)/%$(EXT)=$(DBGDIR)/%.o)
 DBGCFLAGS = -ggdb -O0
 
@@ -24,7 +24,7 @@ DBGCFLAGS = -ggdb -O0
 # Release build settings
 #
 RELDIR = release
-RELEXE = $(addprefix $(RELDIR)\, $(APPNAME))
+RELEXE = $(addprefix $(RELDIR)/, $(APPNAME))
 RELOBJS = $(SRCS:$(SRCDIR)/%$(EXT)=$(RELDIR)/%.o)
 RELCFLAGS = -O2
 

--- a/src/asmx.c
+++ b/src/asmx.c
@@ -4730,7 +4730,7 @@ void DoLabelOp(int typ, int parm, char *labl)
             val = 0;
 
             // open binary file
-            incbin = fopen(word, "r");
+            incbin = fopen(word, "rb");
 
             if (incbin)
             {


### PR DESCRIPTION
I've encountered a few platform-specific bugs or build issues, and I've bundled them into a single PR for convenience. If you only want some of these, I've also split each fix into individual commits so that you may cherry-pick them.

* Recent versions of GCC, including the GCC 15.0.1 that ships with Fedora 42, default to the C23 standard and disable some GNU extensions, resulting in conflicts with new C keywords and failure to find `getopt`-related code that otherwise requires a header. Building under the `gnu99` standard fixes both of these problems.
* MinGW builds for a platform where text and binary output are different. The processing of `INCBIN` opens its source as text, and this will corrupt the data imported on Windows builds.
* The Makefile, when generating the names of output files, uses backslashes to build the final executable name instead of slashes. This means that the final link attempts to escape the `a` of `asmx`, resulting in a file named `releaseasmx` or `debugasmx` instead of putting a file named `asmx` in the `release` or `debug` directories as pretty clearly intended.
